### PR TITLE
Adx-658 email user search

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,6 +94,18 @@ To install ckanext-emailasusername:
      sudo service apache2 reload
 
 
+-------------
+Configuration
+-------------
+
+See step 4 of *Installation* above for essential CKAN configuration required for this plugin to work.
+
+The plugin also offers the following configuration settings that can be set in your ``ckan.ini`` config file::
+
+    emailasusername.search_by_email = True 
+    
+Adding this parameter will allow users to search for other users by entering an email address, wherever the ``user_autocomplete`` action is called, or the     ``ckan.model.User.search()`` function is used. For security reasons the entire email address is required to match the user account (otherwise the feature could be used to infer the email addresses of other users).  This may be useful, for example, when org admins are adding a new member to their org and do not know the username of the user they wish to add.  
+
 -----------------
 Running the Tests
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -102,9 +102,9 @@ See step 4 of *Installation* above for essential CKAN configuration required for
 
 The plugin also offers the following configuration settings that can be set in your ``ckan.ini`` config file::
 
-    emailasusername.search_by_email = True 
-    
-Adding this parameter will allow users to search for other users by entering an email address, wherever the ``user_autocomplete`` action is called, or the     ``ckan.model.User.search()`` function is used. For security reasons the entire email address is required to match the user account (otherwise the feature could be used to infer the email addresses of other users).  This may be useful, for example, when org admins are adding a new member to their org and do not know the username of the user they wish to add.  
+    emailasusername.search_by_username_and_email = True
+
+Adding this parameter will allow users to search for other users by entering an email address, wherever the ``user_autocomplete`` action is called, or the     ``ckan.model.User.search()`` function is used. For security reasons the entire email address is required to match the user account (otherwise the feature could be used to infer the email addresses of other users).  This may be useful, for example, when org admins are adding a new member to their org and do not know the username of the user they wish to add.
 
 -----------------
 Running the Tests

--- a/ckanext/emailasusername/plugin.py
+++ b/ckanext/emailasusername/plugin.py
@@ -24,8 +24,8 @@ class EmailasusernamePlugin(plugins.SingletonPlugin, DefaultTranslation):
 
     # IConfigurer
     def update_config(self, config_):
-        if config_.get("emailasusername.search_by_email"):
-            User.search = search
+        if config_.get("emailasusername.search_by_username_and_email"):
+            User.search = search_by_username_and_email
         toolkit.add_template_directory(config_, 'templates')
         toolkit.add_public_directory(config_, 'public')
         toolkit.add_resource('fanstatic', 'emailasusername')
@@ -96,7 +96,7 @@ def user_emails_match(key, data, errors, context):
 
 
 @classmethod
-def search(cls, querystr, sqlalchemy_query=None, user_name=None):
+def search_by_username_and_email(cls, querystr, sqlalchemy_query=None, user_name=None):
     '''Search name, fullname, email. '''
     if sqlalchemy_query is None:
         query = meta.Session.query(cls)
@@ -112,6 +112,6 @@ def search(cls, querystr, sqlalchemy_query=None, user_name=None):
     if user_name and authz.is_sysadmin(user_name):
         filters.append(cls.email.ilike(qstr))
     else:
-        filters.append(cls.email == qstr[1:-1])
+        filters.append(cls.email == querystr)
     query = query.filter(or_(*filters))
     return query

--- a/ckanext/emailasusername/tests/test_plugin.py
+++ b/ckanext/emailasusername/tests/test_plugin.py
@@ -3,12 +3,41 @@ import ckan.plugins
 import ckan.model
 import ckan.logic.schema
 import ckan.tests.factories
+import ckan.tests.helpers
 import ckanext.emailasusername.plugin as plugin
 import logging
 import pytest
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
+
+
+@pytest.mark.usefixtures(u'clean_db')
+@pytest.mark.ckan_config(u'ckan.plugins', u'emailasusername')
+@pytest.mark.usefixtures(u'with_plugins')
+@pytest.mark.usefixtures(u'with_request_context')
+class TestPlugin(object):
+
+    @pytest.mark.ckan_config(u'emailasusername.search_by_email', u'')
+    def test_search_by_email_without_config(self):
+        identity = {'name': 'login', 'email': 'test@ckan.org', 'password': 'password'}
+        ckan.tests.factories.User(**identity)
+        response = ckan.tests.helpers.call_action('user_autocomplete', {}, q=identity['email'])
+        assert not response
+
+    @pytest.mark.ckan_config(u'emailasusername.search_by_email', u'True')
+    def test_search_by_full_email(self):
+        identity = {'name': 'login', 'email': 'test@ckan.org', 'password': 'password'}
+        ckan.tests.factories.User(**identity)
+        response = ckan.tests.helpers.call_action('user_autocomplete', {}, q=identity['email'])
+        assert len(response) == 1
+
+    @pytest.mark.ckan_config(u'emailasusername.search_by_email', u'True')
+    def test_search_by_partial_email(self):
+        identity = {'name': 'login', 'email': 'test@ckan.org', 'password': 'password'}
+        ckan.tests.factories.User(**identity)
+        response = ckan.tests.helpers.call_action('user_autocomplete', {}, q=identity['email'][:-1])
+        assert not response
 
 
 @pytest.mark.usefixtures(u'clean_db')

--- a/ckanext/emailasusername/tests/test_plugin.py
+++ b/ckanext/emailasusername/tests/test_plugin.py
@@ -16,7 +16,7 @@ log.setLevel(logging.DEBUG)
 @pytest.mark.ckan_config(u'ckan.plugins', u'emailasusername')
 @pytest.mark.usefixtures(u'with_plugins')
 @pytest.mark.usefixtures(u'with_request_context')
-class TestPlugin(object):
+class TestSearchUsersByEmail(object):
 
     @pytest.mark.ckan_config(u'emailasusername.search_by_email', u'')
     def test_search_by_email_without_config(self):


### PR DESCRIPTION
This PR overrides the user search function to include any users with an email that EXACTLY matches the query string 
(replicating the behaviour used by Trello)

For security reasons we don't want to be revealing everyone's email addresses in an auto complete box, but we do want to allow people who know the exact email address to use it to find users. 

This PR allows you to optionally configure CKAN using the emailasusername plugin to return users who's emails exactly match the query string. 

Accompanying PR's should be opened:

- adx_develop to add the `emailasusername.search_by_email = True` config param
- ckanext-unaids to update the "new_member.html" template to label the field "Username / Email" instead of just "Username" There may be other templates where we want to make a similar small change?