### PR TITLE
Updating impl. IAuthenticator to CKAN 2.9.3 and py3

### DIFF
--- a/ckanext/emailasusername/authenticator.py
+++ b/ckanext/emailasusername/authenticator.py
@@ -1,12 +1,13 @@
 # encoding: utf-8
 import logging
-from zope.interface import implements
+from zope.interface import implementer
 from repoze.who.interfaces import IAuthenticator
 from ckanext.emailasusername.blueprint import user_by_username_or_email
 
 log = logging.getLogger(__name__)
 
 
+@implementer(IAuthenticator)
 class EmailAsUsernameAuthenticator(object):
     """
     CKAN uses WSGI authentication middleware who.repoze to manage its
@@ -17,8 +18,6 @@ class EmailAsUsernameAuthenticator(object):
     authenticator. Check the installation instructions for how to update
     who.ini file to do this.
     """
-
-    implements(IAuthenticator)
 
     def authenticate(self, environ, identity):
         log.debug("Authenticate Called")

--- a/ckanext/emailasusername/blueprint.py
+++ b/ckanext/emailasusername/blueprint.py
@@ -23,7 +23,7 @@ def user_by_username_or_email(login, flash_errors=True):
         def not_deleted(user):
             return getattr(user, 'state') != 'deleted'
         user_list = User.by_email(login)
-        user_list = filter(not_deleted, user_list)
+        user_list = list(filter(not_deleted, user_list))
 
         if len(user_list) == 1:
             return user_list[0]


### PR DESCRIPTION
Updating the implementation according to default CKAN 2.9.3 plugin:
```
import logging

from zope.interface import implementer
from repoze.who.interfaces import IAuthenticator

from ckan.model import User

log = logging.getLogger(__name__)


@implementer(IAuthenticator)
class UsernamePasswordAuthenticator(object):

    def authenticate(self, environ, identity):
        if not ('login' in identity and 'password' in identity):
            return None

        login = identity['login']
        user = User.by_name(login)

        if user is None:
            log.debug('Login failed - username %r not found', login)
        elif not user.is_active():
            log.debug('Login as %r failed - user isn\'t active', login)
        elif not user.validate_password(identity['password']):
            log.debug('Login as %r failed - password not valid', login)
        else:
            return user.name

        return None

```

This also makes this extension python3 compatible.
Also fixes issue with `filter` returning iterator not a list in py3.