### PR TITLE
OHT-60 Testing config

### DIFF
--- a/ckanext/emailasusername/tests/test_authenticator.py
+++ b/ckanext/emailasusername/tests/test_authenticator.py
@@ -9,8 +9,6 @@ from ckan.logic import ValidationError
 
 
 @pytest.mark.usefixtures(u'clean_db')
-@pytest.mark.ckan_config(u'ckan.plugins', u'emailasusername')
-@pytest.mark.usefixtures(u'with_plugins')
 @pytest.mark.usefixtures(u'with_request_context')
 @pytest.mark.usefixtures(u'mail_server')
 class TestAuthenticator(object):

--- a/ckanext/emailasusername/tests/test_authenticator.py
+++ b/ckanext/emailasusername/tests/test_authenticator.py
@@ -9,7 +9,6 @@ from ckan.logic import ValidationError
 
 
 @pytest.mark.usefixtures(u'clean_db', 'with_plugins')
-@pytest.mark.usefixtures(u'with_request_context')
 @pytest.mark.usefixtures(u'mail_server')
 class TestAuthenticator(object):
 

--- a/ckanext/emailasusername/tests/test_authenticator.py
+++ b/ckanext/emailasusername/tests/test_authenticator.py
@@ -8,7 +8,7 @@ import mock
 from ckan.logic import ValidationError
 
 
-@pytest.mark.usefixtures(u'clean_db')
+@pytest.mark.usefixtures(u'clean_db', 'with_plugins')
 @pytest.mark.usefixtures(u'with_request_context')
 @pytest.mark.usefixtures(u'mail_server')
 class TestAuthenticator(object):

--- a/ckanext/emailasusername/tests/test_blueprint.py
+++ b/ckanext/emailasusername/tests/test_blueprint.py
@@ -16,8 +16,6 @@ log = logging.getLogger(__name__)
 
 
 @pytest.mark.usefixtures(u'clean_db')
-@pytest.mark.ckan_config(u'ckan.plugins', u'emailasusername')
-@pytest.mark.usefixtures(u'with_plugins')
 @pytest.mark.usefixtures(u'with_request_context')
 @pytest.mark.usefixtures(u'mail_server')
 class TestGetUser(object):
@@ -86,8 +84,6 @@ def _assert_login_page_displayed(response):
 #     assert reset_form.action == url_for('emailasusername.request_reset')
 
 @pytest.mark.usefixtures(u'clean_db')
-@pytest.mark.ckan_config(u'ckan.plugins', u'emailasusername')
-@pytest.mark.usefixtures(u'with_plugins')
 @pytest.mark.usefixtures(u'with_request_context')
 @pytest.mark.usefixtures(u'mail_server')
 class TestRequestResetFunctional(object):

--- a/ckanext/emailasusername/tests/test_blueprint.py
+++ b/ckanext/emailasusername/tests/test_blueprint.py
@@ -16,7 +16,6 @@ log = logging.getLogger(__name__)
 
 
 @pytest.mark.usefixtures(u'clean_db', 'with_plugins')
-@pytest.mark.usefixtures(u'with_request_context')
 @pytest.mark.usefixtures(u'mail_server')
 class TestGetUser(object):
 
@@ -83,8 +82,7 @@ def _assert_login_page_displayed(response):
 #     reset_form = response.forms[1]
 #     assert reset_form.action == url_for('emailasusername.request_reset')
 
-@pytest.mark.usefixtures(u'clean_db')
-@pytest.mark.usefixtures(u'with_request_context')
+@pytest.mark.usefixtures(u'clean_db', 'with_plugins')
 @pytest.mark.usefixtures(u'mail_server')
 class TestRequestResetFunctional(object):
 

--- a/ckanext/emailasusername/tests/test_blueprint.py
+++ b/ckanext/emailasusername/tests/test_blueprint.py
@@ -15,7 +15,7 @@ import mock
 log = logging.getLogger(__name__)
 
 
-@pytest.mark.usefixtures(u'clean_db')
+@pytest.mark.usefixtures(u'clean_db', 'with_plugins')
 @pytest.mark.usefixtures(u'with_request_context')
 @pytest.mark.usefixtures(u'mail_server')
 class TestGetUser(object):

--- a/ckanext/emailasusername/tests/test_logic.py
+++ b/ckanext/emailasusername/tests/test_logic.py
@@ -26,8 +26,6 @@ def identity():
 
 
 @pytest.mark.usefixtures(u'clean_db')
-@pytest.mark.ckan_config(u'ckan.plugins', u'emailasusername')
-@pytest.mark.usefixtures(u'with_plugins')
 @pytest.mark.usefixtures(u'with_request_context')
 class TestSearchUsersByEmail(object):
 
@@ -75,8 +73,6 @@ class TestSearchUsersByEmail(object):
 
 
 @pytest.mark.usefixtures(u'clean_db')
-@pytest.mark.ckan_config(u'ckan.plugins', u'emailasusername')
-@pytest.mark.usefixtures(u'with_plugins')
 @pytest.mark.ckan_config(
     u'ckanext.emailasusername.auto_generate_username_from_email',
     u'true'

--- a/ckanext/emailasusername/tests/test_logic.py
+++ b/ckanext/emailasusername/tests/test_logic.py
@@ -25,7 +25,7 @@ def identity():
     return identity
 
 
-@pytest.mark.usefixtures(u'clean_db')
+@pytest.mark.usefixtures(u'clean_db', 'with_plugins')
 @pytest.mark.usefixtures(u'with_request_context')
 class TestSearchUsersByEmail(object):
 
@@ -72,7 +72,7 @@ class TestSearchUsersByEmail(object):
         assert not response
 
 
-@pytest.mark.usefixtures(u'clean_db')
+@pytest.mark.usefixtures(u'clean_db', 'with_plugins')
 @pytest.mark.ckan_config(
     u'ckanext.emailasusername.auto_generate_username_from_email',
     u'true'

--- a/ckanext/emailasusername/tests/test_plugin.py
+++ b/ckanext/emailasusername/tests/test_plugin.py
@@ -21,7 +21,6 @@ def get_validator_names(validator_list):
 
 
 @pytest.mark.usefixtures(u'clean_db', 'with_plugins')
-@pytest.mark.usefixtures(u'with_request_context')
 class TestEmails(object):
 
     def test_user_emails_match(self):

--- a/ckanext/emailasusername/tests/test_plugin.py
+++ b/ckanext/emailasusername/tests/test_plugin.py
@@ -20,7 +20,7 @@ def get_validator_names(validator_list):
     return list(map(lambda f: f.__name__, validator_list))
 
 
-@pytest.mark.usefixtures(u'clean_db')
+@pytest.mark.usefixtures(u'clean_db', 'with_plugins')
 @pytest.mark.usefixtures(u'with_request_context')
 class TestEmails(object):
 

--- a/ckanext/emailasusername/tests/test_plugin.py
+++ b/ckanext/emailasusername/tests/test_plugin.py
@@ -21,8 +21,6 @@ def get_validator_names(validator_list):
 
 
 @pytest.mark.usefixtures(u'clean_db')
-@pytest.mark.ckan_config(u'ckan.plugins', u'emailasusername')
-@pytest.mark.usefixtures(u'with_plugins')
 @pytest.mark.usefixtures(u'with_request_context')
 class TestEmails(object):
 

--- a/test.ini
+++ b/test.ini
@@ -13,7 +13,7 @@ use = config:../ckan/test-core.ini
 
 # Insert any custom config settings to be used when running your extension's
 # tests here.
-
+ckan.plugins = emailasusername
 
 # Logging configuration
 [loggers]


### PR DESCRIPTION
For some reason I can't get this to work...  We should think about how much time it is worth investing into this. 

For some reason the tests for creating usernames seem to behave as if the plugin isn't loaded.  Stranger still, if you add with_plugins fixture to that test class, all but the very first test pass, with the first still behaving as if the plugin hasn't been loaded.