### PR TITLE
OHT-60 Improve config reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ Ensure you have read and completed step 4 of the *Installation* section above.  
 
 The plugin also offers the following default configuration settings that can be changed in your ``ckan.ini`` config file:
 
-    emailasusername.search_by_username_and_email = True
+    ckanext.emailasusername.search_by_username_and_email = True
 
-ALtering this config parameter will allow users to search for other users by entering an email address, wherever the ``user_autocomplete`` action is called. For security reasons the entire email address is required to match the user account (otherwise the feature could be used to infer the email addresses of other users).  This may be useful, for example, when org admins are adding a new member to their org and do not know the username of the user they wish to add.
+ALtering this config parameter will allow users to search for other users by entering an email address, wherever the ``user_autocomplete`` action is called. For security reasons all users except sysadmins must enter the entire email address in order to match the user account (otherwise the feature could be used to infer the email addresses of other users).  This may be useful, for example, when org admins are adding a new member to their org and do not know the username of the user they wish to add.
 
     ckanext.emailasusername.auto_generate_username_from_email = False
     

--- a/ckanext/emailasusername/helpers.py
+++ b/ckanext/emailasusername/helpers.py
@@ -1,16 +1,24 @@
 from ckan.plugins import toolkit as toolkit
 
 
-def _get_config_value(key, default_value):
-    return toolkit.config.get(
+def _get_config_bool_value(key, default_value):
+    return toolkit.asbool(toolkit.config.get(
         'ckanext.emailasusername.{}'.format(key),
         default_value
-    )
+    ))
 
 
 def config_auto_generate_username_from_fullname():
-    return _get_config_value('auto_generate_username_from_fullname', False)
+    return _get_config_bool_value('auto_generate_username_from_fullname', False)
+
+
+def config_auto_generate_username_from_email():
+    return _get_config_bool_value('auto_generate_username_from_email', False)
 
 
 def config_require_user_email_input_confirmation():
-    return _get_config_value('require_user_email_input_confirmation', True)
+    return _get_config_bool_value('require_user_email_input_confirmation', True)
+
+
+def config_search_by_username_and_email():
+    return _get_config_bool_value('search_by_username_and_email', True)

--- a/ckanext/emailasusername/plugin.py
+++ b/ckanext/emailasusername/plugin.py
@@ -12,10 +12,7 @@ from ckanext.emailasusername.logic import (
     user_autocomplete,
     user_create
 )
-from ckanext.emailasusername.helpers import (
-    config_auto_generate_username_from_fullname,
-    config_require_user_email_input_confirmation
-)
+import ckanext.emailasusername.helpers as helpers
 
 log = logging.getLogger(__name__)
 
@@ -45,9 +42,9 @@ class EmailasusernamePlugin(plugins.SingletonPlugin, DefaultTranslation):
 
     def get_actions(self):
         actions = {}
-        if toolkit.config.get("emailasusername.search_by_username_and_email"):
+        if helpers.config_search_by_username_and_email():
             actions['user_autocomplete'] = user_autocomplete
-        if toolkit.config.get("ckanext.emailasusername.auto_generate_username_from_email"):
+        if helpers.config_auto_generate_username_from_email():
             actions['user_create'] = user_create
         return actions
 
@@ -57,8 +54,10 @@ class EmailasusernamePlugin(plugins.SingletonPlugin, DefaultTranslation):
     # ITemplateHelpers
     def get_helpers(self):
         return {
-            'config_auto_generate_username_from_fullname': config_auto_generate_username_from_fullname,
-            'config_require_user_email_input_confirmation': config_require_user_email_input_confirmation
+            'config_auto_generate_username_from_fullname':
+                helpers.config_auto_generate_username_from_fullname,
+            'config_require_user_email_input_confirmation':
+                helpers.config_require_user_email_input_confirmation
         }
 
 
@@ -82,7 +81,7 @@ def emailasusername_new_user_schema(
     emailasusername_schema['email1'] = [
         not_empty, unicode_safe, email_validator, email_exists
     ]
-    if config_require_user_email_input_confirmation():
+    if helpers.config_require_user_email_input_confirmation():
         emailasusername_schema['email1'] += [
             user_emails_match, user_both_emails_entered
         ]

--- a/ckanext/emailasusername/tests/test_logic.py
+++ b/ckanext/emailasusername/tests/test_logic.py
@@ -31,43 +31,43 @@ def identity():
 @pytest.mark.usefixtures(u'with_request_context')
 class TestSearchUsersByEmail(object):
 
-    @pytest.mark.ckan_config(u'emailasusername.search_by_username_and_email', u'')
+    @pytest.mark.ckan_config(u'ckanext.emailasusername.search_by_username_and_email', u'false')
     def test_search_by_email_without_config(self, identity):
         ckan.tests.factories.User(**identity)
         response = ckan.tests.helpers.call_action('user_autocomplete', {}, q=identity['email'])
         assert not response
 
-    @pytest.mark.ckan_config(u'emailasusername.search_by_username_and_email', u'True')
+    @pytest.mark.ckan_config(u'ckanext.emailasusername.search_by_username_and_email', u'True')
     def test_search_by_full_email(self, identity):
         ckan.tests.factories.User(**identity)
         response = ckan.tests.helpers.call_action('user_autocomplete', {}, q=identity['email'])
         assert len(response) == 1
 
-    @pytest.mark.ckan_config(u'emailasusername.search_by_username_and_email', u'True')
+    @pytest.mark.ckan_config(u'ckanext.emailasusername.search_by_username_and_email', u'True')
     def test_search_by_full_email_case_insensitive(self, identity):
         ckan.tests.factories.User(**identity)
         response = ckan.tests.helpers.call_action('user_autocomplete', {}, q=identity['email'].upper())
         assert len(response) == 1
 
-    @pytest.mark.ckan_config(u'emailasusername.search_by_username_and_email', u'True')
+    @pytest.mark.ckan_config(u'ckanext.emailasusername.search_by_username_and_email', u'True')
     def test_search_by_partial_email_sysadmin(self, sysadmin_context, identity):
         ckan.tests.factories.User(**identity)
         response = ckan.tests.helpers.call_action('user_autocomplete', sysadmin_context, q='test@ckan')
         assert len(response) == 1
 
-    @pytest.mark.ckan_config(u'emailasusername.search_by_username_and_email', u'True')
+    @pytest.mark.ckan_config(u'ckanext.emailasusername.search_by_username_and_email', u'True')
     def test_search_by_partial_email_sysadmin_case_insensitive(self, sysadmin_context, identity):
         ckan.tests.factories.User(**identity)
         response = ckan.tests.helpers.call_action('user_autocomplete', sysadmin_context, q='test@ckan'.upper())
         assert len(response) == 1
 
-    @pytest.mark.ckan_config(u'emailasusername.search_by_username_and_email', u'True')
+    @pytest.mark.ckan_config(u'ckanext.emailasusername.search_by_username_and_email', u'True')
     def test_search_by_nonexisting_email_sysadmin(self, sysadmin_context, identity):
         ckan.tests.factories.User(**identity)
         response = ckan.tests.helpers.call_action('user_autocomplete', sysadmin_context, q='tast@ckan.org')
         assert not response
 
-    @pytest.mark.ckan_config(u'emailasusername.search_by_username_and_email', u'True')
+    @pytest.mark.ckan_config(u'ckanext.emailasusername.search_by_username_and_email', u'True')
     def test_search_by_partial_email(self, identity):
         ckan.tests.factories.User(**identity)
         response = ckan.tests.helpers.call_action('user_autocomplete', {}, q=identity['email'][:-1])


### PR DESCRIPTION
This PR ensures the config is read in a consistent manner and the config params are named consistently.  

This should not break ADR since the default value for search_by_username_or_email is True. 
It should not break other projects since they are using an older version of ckanext-emailasusername.

 